### PR TITLE
Updated reference to old repository name.

### DIFF
--- a/syllabus/collaboration.html
+++ b/syllabus/collaboration.html
@@ -8,7 +8,7 @@
       name="description"
       content="Collaboration as an expectation of CSE 340 is outlined" />
     <meta name="viewport" content="width=device-width" />
-    <link rel="stylesheet" href="/340br/css/340course.css" media="screen" />
+    <link rel="stylesheet" href="/cse340-ww-content/css/340course.css" media="screen" />
   </head>
 
   <body>

--- a/views/account-login.html
+++ b/views/account-login.html
@@ -293,6 +293,6 @@ module.exports = { buildLogin }
         >.
       </footer>
     </div>
-    <script src="/340br/js/prism-coy-dev.min.js"></script>
+    <script src="/cse340-ww-content/js/prism-coy-dev.min.js"></script>
   </body>
 </html>

--- a/views/account-registration.html
+++ b/views/account-registration.html
@@ -225,7 +225,7 @@ module.exports = { buildLogin, buildRegister }
       <a rel="license" href="//creativecommons.org/licenses/by-sa/3.0/deed.en_US">Creative Commons Attribution-ShareAlike 3.0 License</a>.
     </footer>
   </div>
-  <script src="/340br/js/prism-coy-dev.min.js"></script>
+  <script src="/cse340-ww-content/js/prism-coy-dev.min.js"></script>
 </body>
 
 </html>

--- a/views/basic-errors.html
+++ b/views/basic-errors.html
@@ -126,7 +126,7 @@ app.use(async (req, res, next) =&gt; {
         License</a>.
     </footer>
   </div>
-  <script src="/340br/js/prism-coy-dev.min.js"></script>
+  <script src="/cse340-ww-content/js/prism-coy-dev.min.js"></script>
 
 </body>
 

--- a/views/debugging.html
+++ b/views/debugging.html
@@ -65,7 +65,7 @@
         License</a>.
     </footer>
   </div>
-  <script src="/340br/js/prism-coy-dev.min.js"></script>
+  <script src="/cse340-ww-content/js/prism-coy-dev.min.js"></script>
 
 </body>
 

--- a/views/error-handling.html
+++ b/views/error-handling.html
@@ -145,7 +145,7 @@ app.use(async (err, req, res, next) => {
         License</a>.
     </footer>
   </div>
-  <script src="/340br/js/prism-coy-dev.min.js"></script>
+  <script src="/cse340-ww-content/js/prism-coy-dev.min.js"></script>
 
 </body>
 

--- a/views/express-routes.html
+++ b/views/express-routes.html
@@ -142,7 +142,7 @@
         href="//creativecommons.org/licenses/by-sa/3.0/deed.en_US">Creative Commons Attribution-ShareAlike 3.0
         License</a>. </footer>
   </div>
-  <script src="/340br/js/prism-coy-dev.min.js"></script>
+  <script src="/cse340-ww-content/js/prism-coy-dev.min.js"></script>
 
 </body>
 

--- a/views/inv-delivery-classification.html
+++ b/views/inv-delivery-classification.html
@@ -529,6 +529,6 @@ Util.buildClassificationGrid = async function(data){
         >.
       </footer>
     </div>
-    <script src="/340br/js/prism-coy-dev.min.js"></script>
+    <script src="/cse340-ww-content/js/prism-coy-dev.min.js"></script>
   </body>
 </html>

--- a/views/mvc-start.html
+++ b/views/mvc-start.html
@@ -730,7 +730,7 @@ module.exports = Util
       <a rel="license" href="//creativecommons.org/licenses/by-sa/3.0/deed.en_US" title="Read the license" target="_blank">Creative Commons Attribution-ShareAlike 3.0 License</a>.
     </footer>
   </div>
-  <script src="/340br/js/prism-coy-dev.min.js"></script>
+  <script src="/cse340-ww-content/js/prism-coy-dev.min.js"></script>
 </body>
 
 </html>

--- a/views/session-message.html
+++ b/views/session-message.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width" />
   <link rel="stylesheet" href="/cse340-ww-content/css/340course-min.css" type="text/css" media="screen" />
   <link rel="stylesheet" href="/cse340-ww-content/css/prism-coy-dev.min.css" media="screen" />
-  <script defer src="/340br/js/prism-coy-dev.min.js"></script>
+  <script defer src="/cse340-ww-content/js/prism-coy-dev.min.js"></script>
 </head>
 
 <body>

--- a/views/update-one.html
+++ b/views/update-one.html
@@ -142,7 +142,7 @@ invCont.editInventoryView = async function (req, res, next) {
         Commons Attribution-ShareAlike 3.0 License</a>.
     </footer>
   </div>
-  <script src="/340br/js/prism-coy-dev.min.js"></script>
+  <script src="/cse340-ww-content/js/prism-coy-dev.min.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
References to the code formatter js library are going to the old repo name. This causes features such as line numbers to not render correctly.

This PR replaces the old repo name with the correct one.